### PR TITLE
Change global Description setting name to SiteDescription

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -1,5 +1,5 @@
 Host: localhost
 LinksUseHttps: true
 SiteTitle: Title of the blog
-Description: "Cool blog to do cool stuff 1, cool stuff 2 and so on..."
+SiteDescription: "Cool blog to do cool stuff 1, cool stuff 2 and so on..."
 GenerateSearchIndex: true


### PR DESCRIPTION
As per https://github.com/statiqdev/CleanBlog/pull/23#issuecomment-1334983821

> @atiq-cs your template uses a `Description` global setting for the home page subtitle. That should be `SiteDescription` now. The rationale is to not force a `Description` value, that may only make sense when displayed on the home page, to all pages lacking a `Description` setting of their own.