### PR TITLE
Add a masthead image with attribution

### DIFF
--- a/input/posts/welcome.md
+++ b/input/posts/welcome.md
@@ -1,8 +1,11 @@
+---
 Title: Welcome to Statiq Blog
 Lead: An initialized version of Statiq
 Published: 11/11/2021
 Tags:
   - statiq-init
+Image: https://cdn.pixabay.com/photo/2022/11/25/16/30/brown-hairstreak-7616422_960_720.jpg
+ImageAttribution: Photo by <a href="https://pixabay.com/users/erik_karits-15012370">Erik_Karits</a> on <a href="https://pixabay.com/photos/brown-hairstreak-butterfly-insect-7616422">Pixabay</a>
 ---
 
 ## Intro


### PR DESCRIPTION
This PR allows showcasing masthead images and attribution badges, without requiring that a `img` folder be added to the template.