### PR TITLE
Add an About page

### DIFF
--- a/input/pages/about.md
+++ b/input/pages/about.md
@@ -1,0 +1,12 @@
+---
+Order: 1
+NavbarTitle: About
+Title: About the author
+Description: Just in case you were wondering
+Image: https://cdn.pixabay.com/photo/2016/09/02/13/47/machine-1639234_960_720.jpg
+ImageAttribution: Photo by <a href="https://pixabay.com/users/tomasz_mikolajczyk-106840">Tomasz_Mikolajczyk</a> on <a href="https://pixabay.com/photos/machine-printing-keys-font-1639234">Pixabay</a>  
+---
+
+Hey there,
+
+my name is James D. Author and, as you may have guessed, this is my blog.


### PR DESCRIPTION
This PR adds an About page with a masthead image (with attribution, of course) and separate navbar title and display title.