### PR TITLE
Add Copyright global setting

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -2,4 +2,5 @@ Host: localhost
 LinksUseHttps: true
 SiteTitle: Title of the blog
 Description: "Cool blog to do cool stuff 1, cool stuff 2 and so on..."
+Copyright: => @$"All articles © {DateTime.Now.Year} James D. Author"
 GenerateSearchIndex: true


### PR DESCRIPTION
This PR adds a `Copyright` global setting, using Statiq's dynamic settings feature.