### PR TITLE
Add Creative Commons Attribution-ShareAlike 4.0 licensing

### DIFF
--- a/input/_copyright.cshtml
+++ b/input/_copyright.cshtml
@@ -1,0 +1,5 @@
+<p class="copyright">
+  @Document.GetString(WebKeys.Copyright)<br>
+  <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png"></a><br>
+  This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+</p>


### PR DESCRIPTION
This PR demonstrates overriding a Razor partial to add a Creative Commons Attribution-ShareAlike 4.0 license to the blog.