### PR TITLE
Add a default masthead image

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -3,3 +3,7 @@ LinksUseHttps: true
 SiteTitle: Title of the blog
 Description: "Cool blog to do cool stuff 1, cool stuff 2 and so on..."
 GenerateSearchIndex: true
+
+# Default image
+Image: https://cdn.pixabay.com/photo/2022/11/25/16/30/brown-hairstreak-7616422_960_720.jpg
+ImageAttribution: Photo by <a href="https://pixabay.com/users/erik_karits-15012370">Erik_Karits</a> on <a href="https://pixabay.com/photos/brown-hairstreak-butterfly-insect-7616422">Pixabay</a>


### PR DESCRIPTION
This PR adds a default masthead image, shown in all pages (including home and archives) unless they have their own.